### PR TITLE
Fix #3; ensure JVM install before Nexus

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,8 @@ class nexus (
 
   if $nexus::manage_java {
     include nexus::java
+    Class['nexus::java']
+    -> Class['nexus::install']
   }
 
   Class['nexus::install']


### PR DESCRIPTION
This change will fix #3 , ensuring the JVM install and configuration before Nexus request it.