### PR TITLE
Fix #2; JVM options file is a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,24 @@ Type: String
 
 Password to access the keystore
 
+#### `java_xms`
+
+Type: String
+
+The JVM minimum heap size. Default to '512M'.
+
+#### `java_xmx`
+
+Type: String
+
+The JVM maximum heap size. Default to '1200M'.
+
+#### `java_max_direct_mem`
+
+Type: String
+
+The JVM maximum direct memory size. Default to '2G'.
+
 #### `manage_java`
 
 Type: Boolean

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,18 @@ class nexus::config {
     mode   => '0755',
   }
 
+  file { "${nexus::nexus_app_path}/bin/nexus.vmoptions":
+    ensure  => present,
+    owner   => $nexus::nexus_user,
+    group   => $nexus::nexus_group,
+    content => epp('nexus/nexus.vmoptions.epp', {
+      xms            => $nexus::java_xms,
+      xmx            => $nexus::java_xmx,
+      max_direct_mem => $nexus::java_max_direct_mem,
+      work_dir       => $nexus::nexus_data_path,
+    }),
+  }
+
   file { $nexus_config_file:
     ensure  => present,
     owner   => $nexus::nexus_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,9 @@
 # @param [String] revision Nexus revision
 # @param [Integer] http_port Port to serve HTTP
 # @param [Integer] https_port Port to serve HTTPS
+# @param [String] java_xms The JVM minimum heap size. Default to '512M'
+# @param [String] java_xmx The JVM maximum heap size. Default to '1200M'
+# @param [String] java_max_direct_mem The JVM maximum direct memory size. Default to '2G'
 # @param [String] listen_address IP address Nexus listen (same for http and https)
 # @param [Boolean] enable_https Whether to enable HTTPS or not
 # @param [String] https_keystore Path to the keystore.jks
@@ -38,6 +41,9 @@ class nexus (
   Integer[1024,65535] $http_port,
   Integer[1024,65535] $https_port,
   String $listen_address,
+  String $java_xms                = '512M',
+  String $java_xmx                = '1200M',
+  String $java_max_direct_mem     = '2G',
   Boolean $enable_https           = false,
   String $https_keystore          = '',
   String $https_keystore_password = '',

--- a/templates/nexus.vmoptions.epp
+++ b/templates/nexus.vmoptions.epp
@@ -1,0 +1,16 @@
+-Xms<%= $xms %>
+-Xmx<%= $xmx %>
+-XX:MaxDirectMemorySize=<%= $max_direct_mem %>
+-XX:+UnlockDiagnosticVMOptions
+-XX:+UnsyncloadClass
+-XX:+LogVMOutput
+-XX:LogFile=<%= $work_dir %>/log/jvm.log
+-XX:-OmitStackTraceInFastThrow
+-Djava.net.preferIPv4Stack=true
+-Dkaraf.home=.
+-Dkaraf.base=.
+-Dkaraf.etc=etc/karaf
+-Djava.util.logging.config.file=etc/karaf/java.util.logging.properties
+-Dkaraf.data=<%= $work_dir %>
+-Djava.io.tmpdir=<%= $work_dir %>/tmp
+-Dkaraf.startLocalConsole=false


### PR DESCRIPTION
This change create a template for the JVM config file.

It also creates new parameters for main class to allow the
configuration of JVM heap parameters. README file updated with the
details.