### PR TITLE
Fix #11; changes service user's home directory to the Nexus installation dir

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 # Internal class to install Nexus
 class nexus::install {
 
-  if "$nexus::major_version.$nexus::minor_version" < '3.1' {
+  if "${nexus::major_version}.${nexus::minor_version}" < '3.1' {
     fail("This module supports version 3.1 or greater, found: \'${nexus::major_version}.${nexus::minor_version}\'")
   }
 
@@ -24,6 +24,11 @@ class nexus::install {
 
   file { $nexus::temp_path:
     ensure => directory,
+  }
+
+  file { $nexus::data_path:
+      ensure => directory,
+      mode   => '0755',
   }
 
   archive { "${nexus::temp_path}/nexus-${nexus::os_ext}":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,6 +5,11 @@ class nexus::install {
     fail("This module supports version 3.1 or greater, found: \'${nexus::major_version}\'")
   }
 
+  file { $nexus::install_path:
+    ensure => directory,
+    mode   => '0755',
+  }
+
   group { $nexus::nexus_group:
     ensure => present,
   }
@@ -12,7 +17,7 @@ class nexus::install {
   user { $nexus::nexus_user:
     ensure => present,
     groups => [$nexus::nexus_group, 'root'],
-    home   => '/home/nexus',
+    home   => $nexus::install_path,
     shell  => '/bin/bash',
   }
 
@@ -23,11 +28,6 @@ class nexus::install {
 
   file { $nexus::temp_path:
     ensure => directory,
-  }
-
-  file { $nexus::install_path:
-    ensure => directory,
-    mode   => '0755',
   }
 
   archive { "${nexus::temp_path}/nexus-${nexus::os_ext}":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,7 +25,7 @@ class nexus::install {
   file { $nexus::temp_path:
     ensure => directory,
   }
-  
+
   archive { "${nexus::temp_path}/nexus-${nexus::os_ext}":
     ensure        => present,
     extract       => true,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,20 +5,16 @@ class nexus::install {
     fail("This module supports version 3.1 or greater, found: \'${nexus::major_version}\'")
   }
 
-  file { $nexus::install_path:
-    ensure => directory,
-    mode   => '0755',
-  }
-
   group { $nexus::nexus_group:
     ensure => present,
   }
 
   user { $nexus::nexus_user:
-    ensure => present,
-    groups => [$nexus::nexus_group, 'root'],
-    home   => $nexus::install_path,
-    shell  => '/bin/bash',
+    ensure     => present,
+    groups     => [$nexus::nexus_group, 'root'],
+    home       => $nexus::install_path,
+    managehome => true,
+    shell      => '/bin/bash',
   }
 
   File {


### PR DESCRIPTION
This change fix #11.

The Nexus installation directory is now created before the user, and it's used as the service user's home directory.