### PR TITLE
Fix #9; fix the version scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Via git
 class { 'nexus':
   http_listen_address => '192.168.250.80',
   http_port           => 8080,
-  major_version       => 7,
-  minor_version       => 1,
+  major_version       => 3,
+  minor_version       => 7,
+  release_version     => 1,
   revision            => 02,
 }
 ```
@@ -159,6 +160,12 @@ Nexus's major version
 Type: String
 
 Nexus's minor version
+
+#### `release_version`
+
+Type: String
+
+Nexus's release version
 
 #### `revision`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,10 +1,11 @@
 ---
 nexus::nexus_user: 'nexus'
 nexus::nexus_group: 'nexus'
-nexus::service_name: 'nexus3'
+nexus::service_name: 'nexus'
 
-nexus::major_version: '9'
-nexus::minor_version: '0'
+nexus::major_version: '3'
+nexus::minor_version: '9'
+nexus::release_version: '0'
 nexus::revision: '01'
 
 

--- a/data/oses/family/Darwin.yaml
+++ b/data/oses/family/Darwin.yaml
@@ -1,6 +1,6 @@
 ---
 nexus::temp_path: '/tmp'
 nexus::install_path: '/opt/nexus'
-nexus::service_name: 'com.sonatype.nexus3'
+nexus::service_name: 'com.sonatype.nexus'
 nexus::os_ext: 'mac.tgz'
 nexus::service_provider: 'launchd'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class nexus (
   String $os_ext,
   String $major_version,
   String $minor_version,
+  String $release_version,
   String $revision,
   Integer[1024,65535] $http_port,
   Integer[1024,65535] $https_port,
@@ -51,7 +52,7 @@ class nexus (
   String $java_distribution       = 'jre'
 ) {
 
-  $nexus_version = "nexus-3.${nexus::major_version}.${nexus::minor_version}-${nexus::revision}"
+  $nexus_version = "nexus-${nexus::major_version}.${nexus::minor_version}.${nexus::release_version}-${nexus::revision}"
   $nexus_app_path = "${nexus::install_path}/${nexus_version}"
   $nexus_data_path = "${nexus::install_path}/sonatype-work"
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,8 @@
 # Internal class to install Nexus
 class nexus::install {
 
-  if $nexus::major_version < '1' {
-    fail("This module supports version 3.1 or greater, found: \'${nexus::major_version}\'")
+  if "$nexus::major_version.$nexus::minor_version" < '3.1' {
+    fail("This module supports version 3.1 or greater, found: \'${nexus::major_version}.${nexus::minor_version}\'")
   }
 
   group { $nexus::nexus_group:


### PR DESCRIPTION
This change fix the issue #9.

It changes the version scheme by adding a new parameter `release_version`. It also changes the version validation on install class, and the service default name on hiera.