### PR TITLE
Issue #12: Changes code to move the sonatype-work directory

### DIFF
--- a/data/oses/family/Darwin.yaml
+++ b/data/oses/family/Darwin.yaml
@@ -1,6 +1,7 @@
 ---
 nexus::temp_path: '/tmp'
 nexus::install_path: '/opt/nexus'
+nexus::data_path: '/var/lib/nexus'
 nexus::service_name: 'com.sonatype.nexus3'
 nexus::os_ext: 'mac.tgz'
 nexus::service_provider: 'launchd'

--- a/data/oses/family/Debian.yaml
+++ b/data/oses/family/Debian.yaml
@@ -1,5 +1,6 @@
 ---
 nexus::temp_path: '/tmp'
 nexus::install_path: '/opt/nexus'
+nexus::data_path: '/var/lib/nexus'
 nexus::service_provider: 'systemd'
 nexus::os_ext: 'unix.tar.gz'

--- a/data/oses/family/RedHat.yaml
+++ b/data/oses/family/RedHat.yaml
@@ -1,5 +1,6 @@
 ---
 nexus::temp_path: '/tmp'
 nexus::install_path: '/opt/nexus'
+nexus::data_path: '/var/lib/nexus'
 nexus::service_provider: 'systemd'
 nexus::os_ext: 'unix.tar.gz'

--- a/data/oses/family/Windows.yaml
+++ b/data/oses/family/Windows.yaml
@@ -1,5 +1,6 @@
 ---
 nexus::temp_path: 'C:/temp'
 nexus::install_path: 'C:/nexus'
+nexus::data_path: 'C:/nexus'
 nexus::os_ext: 'win64.zip'
 nexus::service_provider: 'windows'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class nexus (
   String $nexus_group,
   String $temp_path,
   String $install_path,
+  String $data_path,
   String $service_name,
   String $service_provider,
   String $os_ext,
@@ -53,7 +54,7 @@ class nexus (
 
   $nexus_version = "nexus-3.${nexus::major_version}.${nexus::minor_version}-${nexus::revision}"
   $nexus_app_path = "${nexus::install_path}/${nexus_version}"
-  $nexus_data_path = "${nexus::install_path}/sonatype-work"
+  $nexus_data_path = "${nexus::data_path}/sonatype-work"
 
   include nexus::install
   include nexus::service

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,6 +30,11 @@ class nexus::install {
     mode   => '0755',
   }
 
+  file { $nexus::data_path:
+    ensure => directory,
+    mode   => '0755',
+  }
+
   archive { "${nexus::temp_path}/nexus-${nexus::os_ext}":
     ensure        => present,
     extract       => true,
@@ -48,6 +53,7 @@ class nexus::install {
   file { $nexus::nexus_data_path:
     ensure  => directory,
     recurse => true,
+    source => "file:///${nexus::install_path}/sonatype-work",
   }
 
   case $facts['os']['family'] {


### PR DESCRIPTION
Changes code to move the sonatype-work directory to /var/lib after the binary file extraction, as suggested in the issue #12.