### PR TITLE
Implements update via module

### DIFF
--- a/lib/facter/nexus_work_dir.rb
+++ b/lib/facter/nexus_work_dir.rb
@@ -1,0 +1,6 @@
+Facter.add(:nexus_work_dir) do
+  confine :kernel => :linux
+  setcode do
+    Facter::Util::Resolution.exec('find / -type d -iname \'sonatype-work\'')
+  end
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,9 +26,8 @@ class nexus::install {
     ensure => directory,
   }
 
-  file { $nexus::data_path:
+  file { $nexus::install_path:
     ensure => directory,
-    mode   => '0755',
   }
 
   archive { "${nexus::temp_path}/nexus-${nexus::os_ext}":
@@ -38,6 +37,7 @@ class nexus::install {
     source        => "https://download.sonatype.com/nexus/3/${nexus::version}-${nexus::os_ext}",
     checksum_url  => "https://download.sonatype.com/nexus/3/${nexus::version}-${nexus::os_ext}.sha1",
     checksum_type => 'sha1',
+    creates       => $nexus::app_path,
     cleanup       => true,
   }
 
@@ -46,10 +46,25 @@ class nexus::install {
     recurse => true,
   }
 
-  file { $nexus::work_dir:
-    ensure  => directory,
+  if $facts['nexus_work_dir'] != $nexus::work_dir {
+    file { $nexus::data_path:
+      ensure => directory,
+      mode   => '0755',
+    }
+
+    file { $nexus::work_dir:
+      ensure  => directory,
+      recurse => true,
+      replace => false,
+      source  => "file:///${nexus::install_path}/sonatype-work",
+      before  => File["${nexus::install_path}/sonatype-work"],
+    }
+  }
+
+  file { "${nexus::install_path}/sonatype-work":
+    ensure  => absent,
+    force   => true,
     recurse => true,
-    source  => "file:///${nexus::install_path}/sonatype-work",
   }
 
   case $facts['os']['family'] {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,11 @@
 # Internal class to manage Nexus service
 class nexus::service {
 
+  class { '::systemd::systemctl::daemon_reload':
+    subscribe => File["/etc/systemd/system/${nexus::service_name}.service"],
+    notify    => Service[$nexus::service_name],
+  }
+
   service { $nexus::service_name:
     ensure     => running,
     provider   => $nexus::service_provider,

--- a/metadata.json
+++ b/metadata.json
@@ -39,6 +39,9 @@
     },
     {
       "name":"puppet/archive"
+    },
+    {
+      "name":"camptocamp/systemd"
     }
   ],
   "pdk-version": "1.2.1",


### PR DESCRIPTION
This pull request implements the module's ability to update Nexus version without losing any data; the previous app directory is kept, and the systemctl daemon is reloaded before restart the service.